### PR TITLE
Exit with a non-zero exit code when triggering the build failed

### DIFF
--- a/copr-build
+++ b/copr-build
@@ -107,7 +107,7 @@ def main():
     except Exception as e:
         logger.error("could not trigger build")
         logger.error(e)
-
+        exit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
All failures should cause a non-zero exit code. Otherwise, failures like e.g. expired or invalid credentials (see for example ublue-os/ublue-update#114) might go unnoticed.